### PR TITLE
fix: handle when ActiveRecord::Store has nil value in #reload

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,11 +32,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1']
+        ruby-version: ['3.0', '3.1', '3.2']
         test: ['minitest', 'rspec']
         gemfile:
-          - Gemfile
-          - Gemfile.rails60
           - Gemfile.rails61
           - Gemfile.rails70
           - Gemfile.railsmaster
@@ -48,10 +46,6 @@ jobs:
         exclude:
           - gemfile: Gemfile.mongo_mapper
             db: postgresql
-          - ruby-version: '3.0'
-            gemfile: Gemfile
-          - ruby-version: '3.1'
-            gemfile: Gemfile
           - ruby-version: '3.0'
             gemfile: Gemfile.mongo_mapper
           - ruby-version: '3.1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix a bug where the value of a false boolean attribute was not properly serialized because it was
   treated as ruby's false in condition and that condition was never met. (by [@nashby](https://github.com/nashby))
+* Make `Enumerize::Value#as_json` return a string, not an instance of `Enumerize::Value` (by [@nashby](https://github.com/nashby))
 
 ### enchancements
 
@@ -17,7 +18,7 @@
 * Warn about already defined predicate methods only when we generate predicate methods with `predicate: true` (by [@nashby](https://github.com/nashby))
 * Define `Type#cast` instead of deserialize to fix serialization issue. (by [@nashby](https://github.com/nashby))
 * Fix `Undefined method 'enumerize' for RSpec::ExampleGroups` (by [@softwaregravy](https://github.com/softwaregravy))
-  
+
 ### enchancements
 
 * Add support for procs as `i18n_scope` option value. (by [@nashby](https://github.com/nashby))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix a bug where the value of a false boolean attribute was not properly serialized because it was
   treated as ruby's false in condition and that condition was never met. (by [@nashby](https://github.com/nashby))
 * Make `Enumerize::Value#as_json` return a string, not an instance of `Enumerize::Value` (by [@nashby](https://github.com/nashby))
+* Fix attribute type casting when Rails master is used (by [@nashby](https://github.com/nashby))
 
 ### enchancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## master
+
+### bug fix
+
+* Fix a bug where the value of a false boolean attribute was not properly serialized because it was
+  treated as ruby's false in condition and that condition was never met. (by [@nashby](https://github.com/nashby))
+
+### enchancements
+
+* Support only Ruby 3+ and Rails 6.1+. (by [@nashby](https://github.com/nashby))
+* Allows the original options specified in enumerize to be retrieved from Enumerize::Attribute. (by [@okoshi-f](https://github.com/okoshi-f))
+
 ## 2.7.0 (July 7, 2023)
 
 ### bug fix

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,0 @@
-eval_gemfile('Gemfile.global')
-
-gem 'minitest', '~> 5.8'
-gem 'rails',    '~> 5.2.4', require: false
-gem 'mongoid'
-gem 'sqlite3', '~> 1.5', :platform => [:ruby, :mswin, :mingw]

--- a/Gemfile.global
+++ b/Gemfile.global
@@ -8,7 +8,7 @@ if ENV['TEST_FRAMEWORK'] == 'rspec'
   gem 'rspec', :require => false
 end
 
-gem 'pg', '~> 1.2.3', :platform => [:ruby, :mswin, :mingw]
+gem 'pg', '~> 1.5.3', :platform => [:ruby, :mswin, :mingw]
 gem 'sequel'
 gem 'simple_form'
 gem 'formtastic'

--- a/Gemfile.mongo_mapper
+++ b/Gemfile.mongo_mapper
@@ -1,6 +1,6 @@
 eval_gemfile('Gemfile.global')
 
 gem 'minitest', '~> 5.8'
-gem 'rails',    '~> 5.2.4', :require => false
+gem 'rails',    github: 'rails/rails', branch: '7-0-stable', require: false
 gem 'mongo_mapper'
 gem 'sqlite3', '~> 1.3.6', :platform => [:ruby, :mswin, :mingw]

--- a/Gemfile.mongo_mapper
+++ b/Gemfile.mongo_mapper
@@ -3,4 +3,4 @@ eval_gemfile('Gemfile.global')
 gem 'minitest', '~> 5.8'
 gem 'rails',    github: 'rails/rails', branch: '7-0-stable', require: false
 gem 'mongo_mapper'
-gem 'sqlite3', '~> 1.3.6', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]

--- a/Gemfile.rails60
+++ b/Gemfile.rails60
@@ -1,6 +1,0 @@
-eval_gemfile('Gemfile.global')
-
-gem 'minitest', '~> 5.8'
-gem 'rails',    '~> 6.0.0', require: false
-gem 'mongoid',  github: 'mongodb/mongoid'
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]

--- a/Gemfile.rails70
+++ b/Gemfile.rails70
@@ -3,7 +3,6 @@ eval_gemfile('Gemfile.global')
 gem 'minitest', '~> 5.8'
 gem 'rails',    github: 'rails/rails', branch: '7-0-stable', require: false
 
-# TODO: Mongoid doesn't support Rails 7 yet. Uncomment when it's fixed https://jira.mongodb.org/browse/MONGOID-5193
-# gem 'mongoid',  github: 'mongodb/mongoid'
+gem 'mongoid',  github: 'mongodb/mongoid'
 
 gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Or install it yourself as:
 
 ## Supported Versions
 
-- Ruby 2.7+
-- Rails 5.2+
+- Ruby 3.0+
+- Rails 6.1+
 
 ## Usage
 

--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -80,7 +80,9 @@ module Enumerize
             end
 
             if store_attr.present?
-              reloaded.send("#{attr.name}=", reloaded.send(store_attr).with_indifferent_access[attr.name])
+              unless reloaded.send(store_attr).nil?
+                reloaded.send("#{attr.name}=", reloaded.send(store_attr).with_indifferent_access[attr.name])
+              end
             else
               reloaded.send("#{attr.name}=", reloaded[attr.name])
             end

--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -21,7 +21,13 @@ module Enumerize
           require 'enumerize/hooks/uniqueness'
 
           unless options[:multiple]
-            if ::ActiveRecord.version >= ::Gem::Version.new("7.0.0.alpha")
+            if ::ActiveRecord.version >= ::Gem::Version.new("7.2.0.alpha")
+              attribute(name)
+
+              decorate_attributes([name]) do |_, subtype|
+                Type.new(enumerized_attributes[name], subtype)
+              end
+            elsif ::ActiveRecord.version >= ::Gem::Version.new("7.0.0.alpha")
               attribute(name) do |subtype|
                 Type.new(enumerized_attributes[name], subtype)
               end

--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -116,7 +116,7 @@ module Enumerize
       end
 
       def cast(value)
-        @attr.find_value(value)
+        @attr.find_value(@subtype.cast(value))
       end
 
       def as_json(options = nil)

--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -110,16 +110,14 @@ module Enumerize
 
       def serialize(value)
         v = @attr.find_value(value)
-        (v && v.value) || value
-      end
+        return value unless v
 
-      alias type_cast_for_database serialize
+        v.value
+      end
 
       def cast(value)
         @attr.find_value(value)
       end
-
-      alias type_cast_from_database cast
 
       def as_json(options = nil)
         {attr: @attr.name}.as_json(options)

--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -122,7 +122,11 @@ module Enumerize
       end
 
       def cast(value)
-        @attr.find_value(@subtype.cast(value))
+        if value.is_a?(::Enumerize::Value)
+          value
+        else
+          @attr.find_value(@subtype.cast(value))
+        end
       end
 
       def as_json(options = nil)

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -2,7 +2,7 @@
 
 module Enumerize
   class Attribute
-    attr_reader :klass, :name, :values, :default_value, :i18n_scope, :skip_validations_value
+    attr_reader :klass, :name, :values, :default_value, :i18n_scope, :skip_validations_value, :origin_options
 
     def initialize(klass, name, options={})
       raise ArgumentError, ':in option is required' unless options[:in]
@@ -13,6 +13,7 @@ module Enumerize
       @klass  = klass
       @name   = name.to_sym
       @i18n_scope = options[:i18n_scope]
+      @origin_options = options
 
       value_class = options.fetch(:value_class, Value)
       @values = Array(options[:in]).map { |v| value_class.new(self, *v).freeze }

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -2,7 +2,7 @@
 
 module Enumerize
   class Attribute
-    attr_reader :klass, :name, :values, :default_value, :i18n_scope, :skip_validations_value, :origin_options
+    attr_reader :klass, :name, :values, :default_value, :i18n_scope, :skip_validations_value, :arguments
 
     def initialize(klass, name, options={})
       raise ArgumentError, ':in option is required' unless options[:in]
@@ -13,7 +13,7 @@ module Enumerize
       @klass  = klass
       @name   = name.to_sym
       @i18n_scope = options[:i18n_scope]
-      @origin_options = options
+      @arguments = options
 
       value_class = options.fetch(:value_class, Value)
       @values = Array(options[:in]).map { |v| value_class.new(self, *v).freeze }

--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -38,6 +38,10 @@ module Enumerize
       coder.represent_object(self.class.superclass, @value)
     end
 
+    def as_json(*)
+      to_s
+    end
+
     private
 
     def predicate_call(value)

--- a/test/activemodel_test.rb
+++ b/test/activemodel_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 if defined?(::ActiveModel::Attributes)
 
-class ActiveModelTest < MiniTest::Spec
+class ActiveModelTest < Minitest::Spec
   class ActiveModelUser
     include ActiveModel::Model
     include ActiveModel::Attributes

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -668,6 +668,18 @@ class ActiveRecordTest < Minitest::Spec
     expect(User.find_by(newsletter_subscribed: false).newsletter_subscribed).must_equal 'unsubscribed'
   end
 
+  it 'has same value with original object when created by #dup' do
+    user1 = User.new(skill: :casual)
+    user2 = user1.dup
+    expect(user2.skill).must_equal 'casual'
+  end
+
+  it 'has same value with original object when created by #clone' do
+    user1 = User.new(skill: :casual)
+    user2 = user1.clone
+    expect(user2.skill).must_equal 'casual'
+  end
+
   if Rails::VERSION::MAJOR >= 6
     it 'supports AR#insert_all' do
       User.delete_all

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -154,7 +154,7 @@ class SkipValidationsLambdaWithParamUser < ActiveRecord::Base
   include SkipValidationsLambdaWithParamEnum
 end
 
-class ActiveRecordTest < MiniTest::Spec
+class ActiveRecordTest < Minitest::Spec
   it 'sets nil if invalid value is passed' do
     user = User.new
     user.sex = :invalid

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 require 'active_record'
 require 'logger'
-
 db = (ENV['DB'] || 'sqlite3').to_sym
 
 silence_warnings do
@@ -663,12 +662,11 @@ class ActiveRecordTest < Minitest::Spec
     User.delete_all
 
     User.create!(newsletter_subscribed: true)
-    expect(User.exists?(newsletter_subscribed: true)).must_equal true
+    expect(User.find_by(newsletter_subscribed: true).newsletter_subscribed).must_equal 'subscribed'
 
     User.create!(newsletter_subscribed: false)
-    expect(User.exists?(newsletter_subscribed: false)).must_equal true
+    expect(User.find_by(newsletter_subscribed: false).newsletter_subscribed).must_equal 'unsubscribed'
   end
-
 
   if Rails::VERSION::MAJOR >= 6
     it 'supports AR#insert_all' do

--- a/test/attribute_map_test.rb
+++ b/test/attribute_map_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 module Enumerize
-  class AttributeMapTest < MiniTest::Spec
+  class AttributeMapTest < Minitest::Spec
     subject { AttributeMap.new }
 
     def make_attr(name)
@@ -52,7 +52,7 @@ module Enumerize
 
     it 'updates dependants' do
       attr = make_attr(:a)
-      dependant = MiniTest::Mock.new
+      dependant = Minitest::Mock.new
       dependant.expect(:<<, nil, [attr])
       subject.add_dependant dependant
       subject << attr

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -42,7 +42,7 @@ class AttributeTest < MiniTest::Spec
   describe 'origin options' do
     it 'returns original options' do
       build_attr nil, :foo, :in => [:a, :b], :scope => true
-      expect(attr.origin_options).must_equal({:is => [:a, :b], :scope => true})
+      expect(attr.origin_options).must_equal({:in => [:a, :b], :scope => true})
     end
   end
 

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -39,6 +39,13 @@ class AttributeTest < MiniTest::Spec
     end
   end
 
+  describe 'origin options' do
+    it 'returns original options' do
+      build_attr nil, :foo, :in => [:a, :b], :scope => true
+      expect(attr.origin_options).must_equal({:is => [:a, :b], :scope => true})
+    end
+  end
+
   describe 'options for select' do
     it 'returns all options for select' do
       store_translations(:en, :enumerize => {:foo => {:a => 'a text', :b => 'b text'}}) do

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -39,10 +39,10 @@ class AttributeTest < MiniTest::Spec
     end
   end
 
-  describe 'origin options' do
-    it 'returns original options' do
+  describe 'arguments' do
+    it 'returns arguments' do
       build_attr nil, :foo, :in => [:a, :b], :scope => true
-      expect(attr.origin_options).must_equal({:in => [:a, :b], :scope => true})
+      expect(attr.arguments).must_equal({:in => [:a, :b], :scope => true})
     end
   end
 

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class AttributeTest < MiniTest::Spec
+class AttributeTest < Minitest::Spec
   def attr
     @attr ||= nil
   end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class BaseTest < MiniTest::Spec
+class BaseTest < Minitest::Spec
   let(:kklass) do
     Class.new do
       extend Enumerize

--- a/test/formtastic_test.rb
+++ b/test/formtastic_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 Formtastic::FormBuilder.action_class_finder = Formtastic::ActionClassFinder
 Formtastic::FormBuilder.input_class_finder  = Formtastic::InputClassFinder
 
-class FormtasticSpec < MiniTest::Spec
+class FormtasticSpec < Minitest::Spec
   include ViewTestHelper
   include Formtastic::Helpers::FormHelper
 

--- a/test/module_attributes_test.rb
+++ b/test/module_attributes_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class ModuleAttributesSpec < MiniTest::Spec
+class ModuleAttributesSpec < Minitest::Spec
   it 'inherits attribute from the module' do
     mod = Module.new do
       extend Enumerize

--- a/test/mongo_mapper_test.rb
+++ b/test/mongo_mapper_test.rb
@@ -10,7 +10,7 @@ end
 
 MongoMapper.connection = Mongo::Client.new(['localhost:27017'], database: 'enumerize-test-suite-of-mongomapper')
 
-class MongoMapperTest < MiniTest::Spec
+class MongoMapperTest < Minitest::Spec
   class MongoMapperUser
     include MongoMapper::Document
     extend Enumerize

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -13,7 +13,7 @@ Mongoid.configure do |config|
   config.options = { use_utc: true, include_root_in_json: true }
 end
 
-class MongoidTest < MiniTest::Spec
+class MongoidTest < Minitest::Spec
   class MongoidUser
     include Mongoid::Document
     extend Enumerize

--- a/test/multiple_test.rb
+++ b/test/multiple_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class MultipleTest < MiniTest::Spec
+class MultipleTest < Minitest::Spec
   let(:kklass) do
     Class.new do
       extend Enumerize

--- a/test/predicates_test.rb
+++ b/test/predicates_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class PredicatesTest < MiniTest::Spec
+class PredicatesTest < Minitest::Spec
   let(:kklass) do
     Class.new do
       extend Enumerize

--- a/test/rails_admin_test.rb
+++ b/test/rails_admin_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class RailsAdminSpec < MiniTest::Spec
+class RailsAdminSpec < Minitest::Spec
   let(:kklass) do
     Class.new do
       extend Enumerize

--- a/test/sequel_test.rb
+++ b/test/sequel_test.rb
@@ -5,7 +5,7 @@ require 'sequel'
 require 'logger'
 require 'jdbc/sqlite3' if RUBY_PLATFORM == 'java'
 
-class SequelTest < MiniTest::Spec
+class SequelTest < Minitest::Spec
   silence_warnings do
     DB = if RUBY_PLATFORM == 'java'
       Sequel.connect('jdbc:sqlite::memory:')

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 require 'yaml'
 
-class SetTest < MiniTest::Spec
+class SetTest < Minitest::Spec
   let(:kklass) do
     Class.new do
       extend Enumerize

--- a/test/simple_form_test.rb
+++ b/test/simple_form_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 require 'simple_form/version'
 
-class SimpleFormSpec < MiniTest::Spec
+class SimpleFormSpec < Minitest::Spec
   include ViewTestHelper
   include SimpleForm::ActionViewExtensions::FormHelper
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,6 +56,6 @@ module MiscHelpers
   end
 end
 
-class MiniTest::Spec
+class Minitest::Spec
   include MiscHelpers
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require 'minitest/autorun'
 require 'minitest/spec'
 require 'active_support/core_ext/kernel/reporting'
 require 'active_model'
+require 'active_job'
 require 'rails'
 begin
   require 'mongoid'

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -162,4 +162,11 @@ class ValueTest < Minitest::Spec
       assert_silent() { Enumerize::Value.new(attr, 'test_value') }
     end
   end
+
+  describe '#as_json' do
+    it 'returns String object, not Value object' do
+      expect(val.as_json.class).must_equal String
+      expect(val.as_json).must_equal 'test_value'
+    end
+  end
 end

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 require 'yaml'
 
-class ValueTest < MiniTest::Spec
+class ValueTest < Minitest::Spec
   class Model
   end
 


### PR DESCRIPTION
An ActiveRecord object could have a store value be nil so check that before trying to access an enumerized store attribute.

Same PR to fix this upstream: https://github.com/brainspec/enumerize/pull/440.